### PR TITLE
enableLog, enableVNC and enableVideo capabilities were set default to true

### DIFF
--- a/selenoid.go
+++ b/selenoid.go
@@ -133,6 +133,11 @@ func create(w http.ResponseWriter, r *http.Request) {
 		queue.Drop()
 		return
 	}
+	if browser.W3CCaps.Caps.ExtensionCapabilities == nil {
+		browser.W3CCaps.Caps.VNC = true
+		browser.W3CCaps.Caps.Video = true
+		browser.W3CCaps.Caps.Log = true
+	}
 	if browser.W3CCaps.Caps.BrowserName() != "" && browser.Caps.BrowserName() == "" {
 		browser.Caps = browser.W3CCaps.Caps
 	}


### PR DESCRIPTION
enableLog, enableVNC and enableVideo values will be true unless `selenoid:options` is present in the `alwaysMatch` capabilities. If `selenoid:options` is present then you need to specify this capabilities by your own.